### PR TITLE
Entity-extraction pipeline, new “Entities” explorer & graph, and power-network perf boost

### DIFF
--- a/src/app/api/entities/route.ts
+++ b/src/app/api/entities/route.ts
@@ -1,0 +1,213 @@
+import { withErrorHandling } from '@/lib/api-utils';
+import { ReportService } from '@/lib/data/report-service';
+import { ExtractedEntity, GraphLink, GraphNode } from '@/lib/types/core';
+import { EntityExtractor } from '@/lib/utils/entity-extraction';
+import { NextResponse } from 'next/server';
+
+interface EntityExtractionRequest {
+    text?: string;
+    reportId?: string;
+    channelId?: string;
+    sourceType?: 'report' | 'message' | 'summary';
+    options?: {
+        minRelevance?: number;
+        entityTypes?: string[];
+        maxPerType?: number;
+    };
+}
+
+export async function POST(request: Request) {
+    return withErrorHandling(async (env) => {
+        const body: EntityExtractionRequest = await request.json();
+        const { text, reportId, channelId, sourceType = 'message', options = {} } = body;
+
+        if (!text) {
+            return NextResponse.json(
+                { error: 'Text is required' },
+                { status: 400 }
+            );
+        }
+
+        const {
+            minRelevance = 0.3,
+            entityTypes,
+            maxPerType = 10
+        } = options;
+
+        // Extract entities
+        const extractionResult = await EntityExtractor.extract(text, {
+            reportId,
+            channelId,
+            sourceType,
+        }, env);
+
+        // Filter entities
+        const filteredEntities = EntityExtractor.filterEntities(
+            extractionResult.entities,
+            entityTypes as ExtractedEntity['type'][],
+            minRelevance
+        );
+
+        // Group by type and limit per type
+        const topEntitiesByType = EntityExtractor.getTopEntitiesByType(
+            filteredEntities,
+            maxPerType
+        );
+
+        return {
+            ...extractionResult,
+            entities: Object.values(topEntitiesByType).flat(),
+            summary: {
+                totalEntities: extractionResult.entities.length,
+                filteredEntities: filteredEntities.length,
+                entityTypes: [...new Set(filteredEntities.map(e => e.type))],
+                topEntities: filteredEntities.slice(0, 5).map(e => ({
+                    type: e.type,
+                    value: e.value,
+                    relevanceScore: e.relevanceScore
+                }))
+            }
+        };
+    }, 'Failed to extract entities');
+}
+
+export async function GET(request: Request) {
+    return withErrorHandling(async env => {
+        const url = new URL(request.url);
+        const reportId = url.searchParams.get('reportId');
+        const format = url.searchParams.get('format');
+
+        // If reportId is provided, get entities for specific report
+        if (reportId) {
+            const extractionResult = await EntityExtractor.getCachedEntities(reportId, env);
+            if (!extractionResult) {
+                return NextResponse.json(
+                    { error: 'Entities not found for this report' },
+                    { status: 404 }
+                );
+            }
+            return { entities: extractionResult.entities };
+        }
+
+        const reportService = new ReportService(env);
+        const reportsWithEntities = await reportService.getReportsWithEntities(100);
+
+        if (format === 'graph') {
+            const nodes: GraphNode[] = [];
+            const links: GraphLink[] = [];
+            const nodeMap = new Map<string, GraphNode>();
+
+            function getNodeId(entity: ExtractedEntity) {
+                return `${entity.type}:${entity.value.toLowerCase()}`;
+            }
+
+            // First pass: create all nodes
+            reportsWithEntities.forEach(report => {
+                if (report.entities?.entities) {
+                    report.entities.entities.forEach(entity => {
+                        const nodeId = getNodeId(entity);
+                        if (!nodeMap.has(nodeId)) {
+                            const newNode = {
+                                id: nodeId,
+                                name: entity.value,
+                                type: entity.type,
+                                relevance: entity.relevanceScore,
+                                connectionCount: 0,
+                            };
+                            nodeMap.set(nodeId, newNode);
+                            nodes.push(newNode);
+                        }
+                    });
+                }
+            });
+
+            const linkMap = new Map<string, GraphLink>();
+
+            // Second pass: create links
+            reportsWithEntities.forEach(report => {
+                if (report.entities?.entities && report.entities.entities.length > 1) {
+                    const reportEntities = report.entities.entities;
+                    for (let i = 0; i < reportEntities.length; i++) {
+                        for (let j = i + 1; j < reportEntities.length; j++) {
+                            const nodeAId = getNodeId(reportEntities[i]);
+                            const nodeBId = getNodeId(reportEntities[j]);
+
+                            if (nodeAId === nodeBId) continue;
+
+                            const linkKey = [nodeAId, nodeBId].sort().join('--');
+                            const existingLink = linkMap.get(linkKey);
+                            if (existingLink) {
+                                existingLink.strength++;
+                            } else {
+                                linkMap.set(linkKey, {
+                                    source: nodeAId,
+                                    target: nodeBId,
+                                    strength: 1,
+                                });
+                            }
+                        }
+                    }
+                }
+            });
+
+            links.push(...linkMap.values());
+
+            // Calculate connection count for each node
+            links.forEach(link => {
+                const sourceNode = nodeMap.get(link.source);
+                const targetNode = nodeMap.get(link.target);
+                if (sourceNode) sourceNode.connectionCount++;
+                if (targetNode) targetNode.connectionCount++;
+            });
+
+            const minConnections = 2;
+            const connectedNodes = nodes.filter(n => n.connectionCount >= minConnections);
+            const connectedNodeIds = new Set(connectedNodes.map(n => n.id));
+
+            const filteredLinks = links.filter(l =>
+                connectedNodeIds.has(l.source) && connectedNodeIds.has(l.target)
+            );
+
+            return {
+                nodes: connectedNodes,
+                links: filteredLinks,
+            };
+        }
+
+        // Otherwise, get aggregated entities from all reports
+        const allEntities: ExtractedEntity[] = [];
+        reportsWithEntities.forEach(report => {
+            if (report.entities?.entities) {
+                allEntities.push(...report.entities.entities);
+            }
+        });
+
+        // Filter and deduplicate entities by value and type
+        const entityMap = new Map<string, ExtractedEntity>();
+        allEntities.forEach(entity => {
+            const key = `${entity.type}:${entity.value.toLowerCase()}`;
+            const existing = entityMap.get(key);
+
+            if (!existing || entity.relevanceScore > existing.relevanceScore) {
+                entityMap.set(key, entity);
+            }
+        });
+
+        const uniqueEntities = Array.from(entityMap.values())
+            .sort((a, b) => b.relevanceScore - a.relevanceScore);
+
+        return {
+            entities: uniqueEntities,
+            totalReports: reportsWithEntities.length,
+            summary: {
+                totalEntities: uniqueEntities.length,
+                entityTypes: [...new Set(uniqueEntities.map(e => e.type))],
+                topEntities: uniqueEntities.slice(0, 10).map(e => ({
+                    type: e.type,
+                    value: e.value,
+                    relevanceScore: e.relevanceScore
+                }))
+            }
+        };
+    }, 'Failed to fetch entities');
+} 

--- a/src/app/entities/EntitiesClient.tsx
+++ b/src/app/entities/EntitiesClient.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Loader } from '@/components/ui/loader';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { ExtractedEntity } from '@/lib/types/core';
+import { ArrowLeft, Search } from 'lucide-react';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+interface EntityWithReports extends ExtractedEntity {
+    reportIds: string[];
+    reportCount: number;
+}
+
+const ENTITY_COLORS = {
+    PERSON: 'bg-blue-100 text-blue-800 border-blue-200',
+    ORGANIZATION: 'bg-green-100 text-green-800 border-green-200',
+    LOCATION: 'bg-purple-100 text-purple-800 border-purple-200',
+    EVENT: 'bg-orange-100 text-orange-800 border-orange-200',
+    PRODUCT: 'bg-cyan-100 text-cyan-800 border-cyan-200',
+    MONEY: 'bg-yellow-100 text-yellow-800 border-yellow-200',
+    DATE: 'bg-pink-100 text-pink-800 border-pink-200',
+    MISC: 'bg-gray-100 text-gray-800 border-gray-200',
+};
+
+const ENTITY_LABELS = {
+    PERSON: 'People',
+    ORGANIZATION: 'Organizations',
+    LOCATION: 'Locations',
+    EVENT: 'Events',
+    PRODUCT: 'Products',
+    MONEY: 'Financial',
+    DATE: 'Dates',
+    MISC: 'Other',
+};
+
+export default function EntitiesClient() {
+    const [entities, setEntities] = useState<EntityWithReports[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [searchQuery, setSearchQuery] = useState('');
+    const [selectedType, setSelectedType] = useState<string>('all');
+
+    useEffect(() => {
+        fetchEntities();
+    }, []);
+
+    const fetchEntities = async () => {
+        try {
+            const response = await fetch('/api/entities');
+            if (!response.ok) throw new Error('Failed to fetch entities');
+
+            const data = await response.json();
+
+            // Aggregate entities across all reports
+            const entityMap = new Map<string, EntityWithReports>();
+
+            data.entities?.forEach((entity: ExtractedEntity) => {
+                const key = `${entity.type}:${entity.value}`;
+                if (entityMap.has(key)) {
+                    const existing = entityMap.get(key)!;
+                    existing.reportCount++;
+                    existing.mentions.push(...entity.mentions);
+                    existing.relevanceScore = Math.max(existing.relevanceScore, entity.relevanceScore);
+                } else {
+                    entityMap.set(key, {
+                        ...entity,
+                        reportIds: [], // We'd need to track this in the API
+                        reportCount: 1,
+                    });
+                }
+            });
+
+            const aggregatedEntities = Array.from(entityMap.values())
+                .sort((a, b) => b.reportCount - a.reportCount || b.relevanceScore - a.relevanceScore);
+
+            setEntities(aggregatedEntities);
+        } catch (error) {
+            console.error('Error fetching entities:', error);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const filteredEntities = entities.filter(entity => {
+        const matchesSearch = entity.value.toLowerCase().includes(searchQuery.toLowerCase());
+        const matchesType = selectedType === 'all' || entity.type === selectedType;
+        return matchesSearch && matchesType;
+    });
+
+    const entityTypes = Array.from(new Set(entities.map(e => e.type)));
+
+    if (loading) {
+        return (
+            <div className="min-h-screen flex items-center justify-center">
+                <div className="text-center">
+                    <Loader size="lg" className="mx-auto mb-4" />
+                    <p className="text-lg text-muted-foreground">Loading entities...</p>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="container mx-auto px-4 py-8">
+            {/* Header */}
+            <div className="mb-8">
+                <div className="flex items-center gap-4 mb-4">
+                    <Link href="/current-events">
+                        <Button variant="ghost" size="sm">
+                            <ArrowLeft className="h-4 w-4 mr-2" />
+                            Back to Reports
+                        </Button>
+                    </Link>
+                </div>
+                <h1 className="text-3xl font-bold mb-2">Entities</h1>
+                <p className="text-muted-foreground">
+                    Key people, organizations, and locations mentioned in news reports
+                </p>
+            </div>
+
+            <div className="mb-4">
+                <Link href="/entities/graph">
+                    <Button variant="outline">
+                        View Entity Graph
+                    </Button>
+                </Link>
+            </div>
+
+            {/* Filters */}
+            <div className="flex flex-col sm:flex-row gap-4 mb-8">
+                <div className="relative flex-1">
+                    <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                    <Input
+                        placeholder="Search entities..."
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery(e.target.value)}
+                        className="pl-10"
+                    />
+                </div>
+                <Select value={selectedType} onValueChange={setSelectedType}>
+                    <SelectTrigger className="w-full sm:w-48">
+                        <SelectValue placeholder="Filter by type" />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="all">All Types</SelectItem>
+                        {entityTypes.map(type => (
+                            <SelectItem key={type} value={type}>
+                                {ENTITY_LABELS[type as keyof typeof ENTITY_LABELS]}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            </div>
+
+            {/* Stats */}
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8">
+                <Card>
+                    <CardContent className="p-4 text-center">
+                        <div className="text-2xl font-bold text-gray-900">{entities.length}</div>
+                        <div className="text-sm text-gray-600">Total Entities</div>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardContent className="p-4 text-center">
+                        <div className="text-2xl font-bold text-gray-900">{entityTypes.length}</div>
+                        <div className="text-sm text-gray-600">Entity Types</div>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardContent className="p-4 text-center">
+                        <div className="text-2xl font-bold text-gray-900">
+                            {entities.reduce((sum, e) => sum + e.reportCount, 0)}
+                        </div>
+                        <div className="text-sm text-gray-600">Total Mentions</div>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardContent className="p-4 text-center">
+                        <div className="text-2xl font-bold text-gray-900">{filteredEntities.length}</div>
+                        <div className="text-sm text-gray-600">Filtered</div>
+                    </CardContent>
+                </Card>
+            </div>
+
+            {/* Entity Grid */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+                {filteredEntities.map((entity, index) => (
+                    <Card key={index} className="hover:shadow-md transition-shadow">
+                        <CardHeader className="pb-2">
+                            <div className="flex items-start justify-between">
+                                <CardTitle className="text-lg line-clamp-2">
+                                    {entity.value}
+                                </CardTitle>
+                                <Badge
+                                    variant="outline"
+                                    className={`${ENTITY_COLORS[entity.type]} text-xs shrink-0 ml-2`}
+                                >
+                                    {ENTITY_LABELS[entity.type as keyof typeof ENTITY_LABELS]}
+                                </Badge>
+                            </div>
+                        </CardHeader>
+                        <CardContent className="pt-0">
+                            <div className="space-y-2">
+                                <div className="flex justify-between text-sm">
+                                    <span className="text-gray-600">Reports:</span>
+                                    <span className="font-medium text-gray-900">{entity.reportCount}</span>
+                                </div>
+                                <div className="flex justify-between text-sm">
+                                    <span className="text-gray-600">Mentions:</span>
+                                    <span className="font-medium text-gray-900">{entity.mentions.length}</span>
+                                </div>
+                                <div className="flex justify-between text-sm">
+                                    <span className="text-gray-600">Relevance:</span>
+                                    <span className="font-medium text-gray-900">
+                                        {(entity.relevanceScore * 100).toFixed(0)}%
+                                    </span>
+                                </div>
+                                {entity.mentions.length > 0 && (
+                                    <div className="pt-2 border-t">
+                                        <p className="text-xs text-gray-600 mb-1">Recent mention:</p>
+                                        <p className="text-xs line-clamp-2 text-gray-800">
+                                            &ldquo;{entity.mentions[0].text}&rdquo;
+                                        </p>
+                                    </div>
+                                )}
+                            </div>
+                        </CardContent>
+                    </Card>
+                ))}
+            </div>
+
+            {filteredEntities.length === 0 && !loading && (
+                <div className="text-center py-12">
+                    <p className="text-lg text-gray-700">No entities found</p>
+                    <p className="text-sm text-gray-600 mt-2">
+                        Try adjusting your search or filter criteria
+                    </p>
+                </div>
+            )}
+        </div>
+    );
+} 

--- a/src/app/entities/graph/EntityGraphClient.tsx
+++ b/src/app/entities/graph/EntityGraphClient.tsx
@@ -1,0 +1,295 @@
+'use client';
+
+import { Loader } from '@/components/ui/loader';
+import { ENTITY_COLORS, ENTITY_LABELS } from '@/lib/config';
+import { GraphData, GraphLink, GraphNode, TransformedGraphData } from '@/lib/types/core';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+import {
+    useCanvasCamera,
+    useFilters,
+    useForceSimulation,
+    useMobileBreakpoint,
+    useNetworkRenderer,
+    useNodes,
+    useNodeSelection,
+    type Node
+} from '../../../lib/hooks';
+
+const ENTITY_TYPES = Object.keys(ENTITY_LABELS);
+
+export default function EntityGraphClient() {
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const [showTopConnected, setShowTopConnected] = useState(false);
+
+    // Data & layout
+    const [graphData, setGraphData] = useState<TransformedGraphData | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        async function fetchData() {
+            try {
+                setLoading(true);
+                const response = await fetch('/api/entities?format=graph');
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch graph data: ${response.statusText}`);
+                }
+                const data: GraphData = await response.json();
+
+                // The API returns { nodes, links }. We need to transform it for the hooks.
+                const transformedData: TransformedGraphData = {
+                    entities: data.nodes.reduce((acc: { [key: string]: GraphNode }, node: GraphNode) => {
+                        acc[node.id] = node;
+                        return acc;
+                    }, {}),
+                    relationships: data.links.map((link: GraphLink) => ({
+                        from: link.source,
+                        to: link.target,
+                        type: 'co-occurrence',
+                        strength: link.strength
+                    })),
+                };
+                setGraphData(transformedData);
+            } catch (err) {
+                if (err instanceof Error) {
+                    setError(err.message);
+                } else {
+                    setError('An unknown error occurred');
+                }
+            } finally {
+                setLoading(false);
+            }
+        }
+        fetchData();
+    }, []);
+
+    const isMobile = useMobileBreakpoint(768);
+    const { filters, searchTerm, setSearchTerm, toggleFilter, isNodeVisible } = useFilters(ENTITY_TYPES);
+
+    // Nodes & physics
+    const { nodesRef } = useNodes(graphData, isMobile);
+    const tick = useForceSimulation(nodesRef, graphData?.relationships);
+
+    // Camera & interaction
+    const { cameraRef, onWheel, onPanStart, onPanMove, onPanEnd, onTouchStart, onTouchMove, onTouchEnd, centerOnNode } = useCanvasCamera();
+
+    // Node selection with proper isNodeVisible binding
+    const isNodeVisibleBound = (node: Node) => isNodeVisible(node, selectedNode, graphData?.relationships);
+    const { selectedNode, setSelectedNode, canvasHandlers } = useNodeSelection(nodesRef, cameraRef, isNodeVisibleBound);
+
+    // Rendering
+    useNetworkRenderer({
+        canvasRef,
+        nodesRef,
+        relationships: graphData?.relationships,
+        cameraRef,
+        selectedNode,
+        isNodeVisible: isNodeVisibleBound,
+        tick,
+    });
+
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center h-full w-full bg-gray-900">
+                <div className="text-center">
+                    <Loader size="lg" className="mx-auto mb-4" />
+                    <p className="text-lg text-white">Loading Entity Graph...</p>
+                </div>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="flex items-center justify-center h-full w-full bg-gray-900">
+                <div className="text-red-400 text-lg">Error: {error}</div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="relative h-screen w-full overflow-hidden">
+            <Link
+                href="/entities"
+                className="absolute top-5 left-5 z-10 opacity-100"
+            >
+                <Image src="/images/brain_transparent.webp" alt="Return to entity list" width={32} height={32} />
+            </Link>
+
+            <div className="absolute top-4 left-20 bg-gray-800 p-2 rounded-lg flex flex-col sm:flex-row sm:items-center gap-2 z-20">
+                <input
+                    type="text"
+                    placeholder="Search entities..."
+                    value={searchTerm}
+                    onChange={(e) => setSearchTerm(e.target.value)}
+                    className="bg-gray-700 text-white text-xs px-2 py-1 rounded focus:outline-none"
+                />
+                <div className="flex flex-wrap items-center gap-2 text-xs text-gray-300">
+                    {ENTITY_TYPES.map((type) => (
+                        <label key={type} className="flex items-center gap-1 cursor-pointer select-none">
+                            <input
+                                type="checkbox"
+                                checked={filters[type.toLowerCase()]}
+                                onChange={() => toggleFilter(type.toLowerCase())}
+                                className="accent-cyan-400 h-3 w-3"
+                            />
+                            <span className="capitalize">{ENTITY_LABELS[type]}</span>
+                        </label>
+                    ))}
+                </div>
+            </div>
+
+            <canvas
+                ref={canvasRef}
+                className="w-full h-full bg-gray-900 cursor-grab active:cursor-grabbing"
+                style={{ touchAction: 'none' }}
+                onMouseDown={(e) => {
+                    const result = canvasHandlers.onMouseDown(e);
+                    if (result.type === 'pan') {
+                        onPanStart(result.startPos.x, result.startPos.y);
+                    }
+                }}
+                onMouseMove={(e) => {
+                    const result = canvasHandlers.onMouseMove(e);
+                    if (result.type === 'pan') {
+                        onPanMove(result.clientPos.x, result.clientPos.y);
+                    }
+                }}
+                onMouseUp={() => {
+                    canvasHandlers.onMouseUp();
+                    onPanEnd();
+                }}
+                onTouchStart={(e) => {
+                    onTouchStart(e);
+                    const result = canvasHandlers.onTouchStart(e);
+                    if (result.type === 'pan') {
+                        onPanStart(result.startPos.x, result.startPos.y);
+                    }
+                }}
+                onTouchMove={(e) => {
+                    onTouchMove(e);
+                    const result = canvasHandlers.onTouchMove(e);
+                    if (result.type === 'pan') {
+                        onPanMove(result.clientPos.x, result.clientPos.y);
+                    }
+                }}
+                onTouchEnd={(e) => {
+                    onTouchEnd(e);
+                    canvasHandlers.onTouchEnd(e);
+                    onPanEnd();
+                }}
+                onWheel={onWheel}
+                width={typeof window !== 'undefined' ? window.innerWidth : 800}
+                height={typeof window !== 'undefined' ? window.innerHeight : 600}
+            />
+
+            {selectedNode && graphData && (
+                <div className="absolute top-4 right-4 bg-gray-800 p-4 rounded-lg border border-gray-600 min-w-48 max-w-80">
+                    <h3 className="text-white font-bold text-lg">{selectedNode.name}</h3>
+                    <p className="text-gray-300 capitalize">{ENTITY_LABELS[selectedNode.type] || selectedNode.type}</p>
+
+                    <p className="text-gray-400 text-sm">Connections: {selectedNode.connectionCount}</p>
+
+                    {(() => {
+                        if (!graphData) return null;
+                        const connections = graphData.relationships
+                            .filter(rel => rel.from === selectedNode.id || rel.to === selectedNode.id)
+                            .map(rel => {
+                                const otherId = rel.from === selectedNode.id ? rel.to : rel.from;
+                                const otherEntity = graphData.entities[otherId];
+                                return {
+                                    type: rel.type,
+                                    name: otherEntity?.name || otherId,
+                                    entityType: otherEntity?.type || 'unknown'
+                                };
+                            })
+                            .sort((a, b) => a.name.localeCompare(b.name));
+
+                        return connections.length > 0 ? (
+                            <div className="mt-3 pt-3 border-t border-gray-600">
+                                <p className="text-gray-300 text-sm font-medium mb-2">
+                                    Connections ({connections.length})
+                                </p>
+                                <div className="space-y-1 max-h-32 overflow-y-auto">
+                                    {connections.map((conn, index) => (
+                                        <div key={index} className="text-xs text-gray-400">
+                                            {conn.name}
+                                            <span className="text-gray-500 ml-1">({ENTITY_LABELS[conn.entityType] || conn.entityType})</span>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        ) : (
+                            <div className="mt-3 pt-3 border-t border-gray-600">
+                                <p className="text-gray-400 text-sm">No connections in current view</p>
+                            </div>
+                        );
+                    })()}
+
+                    <button
+                        onClick={() => setSelectedNode(null)}
+                        className="mt-3 text-gray-400 hover:text-white text-sm"
+                    >
+                        Close
+                    </button>
+                </div>
+            )}
+
+            {/* Legend */}
+            <div className="absolute bottom-4 left-4 bg-gray-800 p-3 rounded-lg border border-gray-600 text-xs">
+                <h4 className="text-white font-medium mb-2">Entity Types</h4>
+                <div className="space-y-1 text-gray-300">
+                    {Object.entries(ENTITY_LABELS).map(([type, label]) => (
+                        <div key={type} className="flex items-center gap-2">
+                            <div
+                                className="w-3 h-3 rounded-full"
+                                style={{ backgroundColor: ENTITY_COLORS[type as keyof typeof ENTITY_COLORS] }}
+                            />
+                            <span>{label}</span>
+                        </div>
+                    ))}
+                </div>
+                <button
+                    onClick={() => setShowTopConnected(!showTopConnected)}
+                    className="mt-2 text-cyan-400 hover:text-cyan-300 text-xs"
+                >
+                    {showTopConnected ? 'Hide' : 'Show'} Top Connected
+                </button>
+            </div>
+
+            {/* Top Connected Panel */}
+            {showTopConnected && graphData && (
+                <div className="absolute bottom-4 right-4 bg-gray-800 p-3 rounded-lg border border-gray-600 max-w-xs">
+                    <h4 className="text-white font-medium mb-2 text-sm">Most Connected Entities</h4>
+                    <div className="space-y-1 max-h-64 overflow-y-auto">
+                        {nodesRef.current
+                            .sort((a: Node, b: Node) => (b.connectionCount || 0) - (a.connectionCount || 0))
+                            .slice(0, 25)
+                            .map((node: Node, index: number) => (
+                                <div
+                                    key={node.id}
+                                    className="flex items-center justify-between text-xs cursor-pointer hover:bg-gray-700 p-1 rounded"
+                                    onClick={() => {
+                                        setSelectedNode(node);
+                                        // Center camera on node
+                                        centerOnNode(node.x, node.y, window.innerWidth, window.innerHeight);
+                                    }}
+                                >
+                                    <div className="flex items-center gap-2">
+                                        <span className="text-gray-400">#{index + 1}</span>
+                                        <span className='text-white'>
+                                            {node.name}
+                                        </span>
+                                    </div>
+                                    <span className="text-yellow-400 font-medium">{node.connectionCount}</span>
+                                </div>
+                            ))
+                        }
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+} 

--- a/src/app/entities/graph/page.tsx
+++ b/src/app/entities/graph/page.tsx
@@ -1,0 +1,12 @@
+import { Metadata } from 'next';
+import EntityGraphClient from './EntityGraphClient';
+
+export const metadata: Metadata = {
+    title: 'Entity Graph - Fast Takeoff',
+    description: 'Interactive visualization of entities and their connections from news reports.',
+    keywords: 'entity graph, news analysis, data visualization, connected entities',
+};
+
+export default function EntityGraphPage() {
+    return <EntityGraphClient />;
+} 

--- a/src/app/entities/page.tsx
+++ b/src/app/entities/page.tsx
@@ -1,0 +1,12 @@
+import { Metadata } from 'next';
+import EntitiesClient from './EntitiesClient';
+
+export const metadata: Metadata = {
+    title: 'Entities - Fast Takeoff',
+    description: 'Explore key entities mentioned in news reports',
+    keywords: 'entities, people, organizations, locations, news analysis',
+};
+
+export default function EntitiesPage() {
+    return <EntitiesClient />;
+} 

--- a/src/app/power-network/NetworkVisualization.tsx
+++ b/src/app/power-network/NetworkVisualization.tsx
@@ -145,7 +145,7 @@ export default function NetworkVisualization() {
                 <div className="absolute top-4 right-4 bg-gray-800 p-4 rounded-lg border border-gray-600 min-w-48 max-w-80">
                     <h3 className="text-white font-bold text-lg">{selectedNode.name}</h3>
                     <p className="text-gray-300 capitalize">{selectedNode.type}</p>
-                    {selectedNode.country && (
+                    {selectedNode?.country && (
                         <p className="text-gray-400 text-sm">{selectedNode.country}</p>
                     )}
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -35,6 +35,9 @@ export default function Header() {
                 <Link href="/current-events" className="text-sm font-medium hover:underline">
                     Current Events
                 </Link>
+                <Link href="/entities" className="text-sm font-medium hover:underline">
+                    Entities
+                </Link>
                 <Link href="/message-activity" className="text-sm font-medium hover:underline">
                     Heatmap
                 </Link>
@@ -82,6 +85,9 @@ export default function Header() {
                                     }
                                     <Link href="/current-events" className="text-sm font-medium hover:underline">
                                         Current Events
+                                    </Link>
+                                    <Link href="/entities" className="text-sm font-medium hover:underline">
+                                        Entities
                                     </Link>
                                     <Link href="/message-activity" className="text-sm font-medium hover:underline">
                                         Heatmap
@@ -140,6 +146,9 @@ export default function Header() {
                                     }
                                     <Link href="/current-events" className="text-sm font-medium hover:underline">
                                         Current Events
+                                    </Link>
+                                    <Link href="/entities" className="text-sm font-medium hover:underline">
+                                        Entities
                                     </Link>
                                     <Link href="/message-activity" className="text-sm font-medium hover:underline">
                                         Heatmap

--- a/src/components/current-events/EntityDisplay.tsx
+++ b/src/components/current-events/EntityDisplay.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ExtractedEntity } from '@/lib/types/core';
+
+interface EntityDisplayProps {
+    entities: ExtractedEntity[];
+    showMentions?: boolean;
+    maxPerType?: number;
+}
+
+const ENTITY_COLORS = {
+    PERSON: 'bg-blue-100 text-blue-800 border-blue-200',
+    ORGANIZATION: 'bg-green-100 text-green-800 border-green-200',
+    LOCATION: 'bg-purple-100 text-purple-800 border-purple-200',
+    EVENT: 'bg-orange-100 text-orange-800 border-orange-200',
+    PRODUCT: 'bg-cyan-100 text-cyan-800 border-cyan-200',
+    MONEY: 'bg-yellow-100 text-yellow-800 border-yellow-200',
+    DATE: 'bg-pink-100 text-pink-800 border-pink-200',
+    MISC: 'bg-gray-100 text-gray-800 border-gray-200',
+};
+
+const ENTITY_LABELS = {
+    PERSON: 'People',
+    ORGANIZATION: 'Organizations',
+    LOCATION: 'Locations',
+    EVENT: 'Events',
+    PRODUCT: 'Products',
+    MONEY: 'Financial',
+    DATE: 'Dates',
+    MISC: 'Other',
+};
+
+export function EntityDisplay({ entities, showMentions = false, maxPerType = 5 }: EntityDisplayProps) {
+    if (!entities || entities.length === 0) {
+        return (
+            <Card className="w-full">
+                <CardHeader>
+                    <CardTitle className="text-sm">Entities</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <p className="text-sm text-gray-500">No entities found</p>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    // Group entities by type
+    const groupedEntities = entities.reduce((acc, entity) => {
+        if (!acc[entity.type]) {
+            acc[entity.type] = [];
+        }
+        if (acc[entity.type].length < maxPerType) {
+            acc[entity.type].push(entity);
+        }
+        return acc;
+    }, {} as Record<string, ExtractedEntity[]>);
+
+    // Sort entity types by importance (based on total relevance score)
+    const sortedTypes = Object.keys(groupedEntities).sort((a, b) => {
+        const aScore = groupedEntities[a].reduce((sum, e) => sum + e.relevanceScore, 0);
+        const bScore = groupedEntities[b].reduce((sum, e) => sum + e.relevanceScore, 0);
+        return bScore - aScore;
+    });
+
+    return (
+        <Card className="w-full">
+            <CardHeader>
+                <CardTitle className="text-sm">Entities ({entities.length})</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                {sortedTypes.map(type => (
+                    <div key={type}>
+                        <h4 className="text-xs font-medium text-gray-600 mb-2">
+                            {ENTITY_LABELS[type as keyof typeof ENTITY_LABELS]}
+                        </h4>
+                        <div className="flex flex-wrap gap-1">
+                            {groupedEntities[type].map((entity, index) => (
+                                <EntityBadge
+                                    key={`${entity.value}-${index}`}
+                                    entity={entity}
+                                    showMentions={showMentions}
+                                />
+                            ))}
+                        </div>
+                    </div>
+                ))}
+            </CardContent>
+        </Card>
+    );
+}
+
+interface EntityBadgeProps {
+    entity: ExtractedEntity;
+    showMentions?: boolean;
+}
+
+function EntityBadge({ entity, showMentions }: EntityBadgeProps) {
+    const colorClass = ENTITY_COLORS[entity.type] || ENTITY_COLORS.MISC;
+    const confidenceScore = entity.mentions.reduce((sum, m) => sum + m.confidence, 0) / entity.mentions.length;
+
+    return (
+        <div className="group relative">
+            <Badge
+                variant="outline"
+                className={`${colorClass} text-xs cursor-help`}
+                title={`Relevance: ${(entity.relevanceScore * 100).toFixed(0)}% | Confidence: ${(confidenceScore * 100).toFixed(0)}%`}
+            >
+                {entity.value}
+                {entity.mentions.length > 1 && (
+                    <span className="ml-1 text-xs opacity-70">
+                        ({entity.mentions.length})
+                    </span>
+                )}
+            </Badge>
+
+            {showMentions && entity.mentions.length > 0 && (
+                <div className="absolute z-10 invisible group-hover:visible bg-black text-white text-xs rounded p-2 mt-1 max-w-xs">
+                    <div className="font-medium mb-1">Mentions:</div>
+                    {entity.mentions.slice(0, 3).map((mention, index) => (
+                        <div key={index} className="text-xs opacity-90">
+                            &ldquo;{mention.text}&rdquo; ({(mention.confidence * 100).toFixed(0)}%)
+                        </div>
+                    ))}
+                    {entity.mentions.length > 3 && (
+                        <div className="text-xs opacity-70">
+                            +{entity.mentions.length - 3} more
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+interface EntitySummaryProps {
+    entities: ExtractedEntity[];
+}
+
+export function EntitySummary({ entities }: EntitySummaryProps) {
+    if (!entities || entities.length === 0) return null;
+
+    const typeCounts = entities.reduce((acc, entity) => {
+        acc[entity.type] = (acc[entity.type] || 0) + 1;
+        return acc;
+    }, {} as Record<string, number>);
+
+    const topEntities = entities
+        .sort((a, b) => b.relevanceScore - a.relevanceScore)
+        .slice(0, 3);
+
+    return (
+        <div className="text-xs text-gray-600 space-y-1">
+            <div>
+                {Object.entries(typeCounts).map(([type, count], index) => (
+                    <span key={type}>
+                        {index > 0 && ' • '}
+                        {count} {ENTITY_LABELS[type as keyof typeof ENTITY_LABELS]?.toLowerCase()}
+                    </span>
+                ))}
+            </div>
+            {topEntities.length > 0 && (
+                <div className="flex flex-wrap gap-1">
+                    {topEntities.map((entity, index) => (
+                        <Badge key={index} variant="secondary" className="text-xs">
+                            {entity.value}
+                        </Badge>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+} 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -92,16 +92,21 @@ export const CACHE = {
         MESSAGES: 2592000, // 30 days
         // Feeds summary cache TTL
         FEEDS: 30 * 24 * 60 * 60, // 30 days
+        // Entity extraction cache TTL
+        ENTITIES: 24 * 60 * 60, // 24 hours
     },
     RETENTION: {
         // How long to keep reports in the KV store before manual cleanup (in seconds)
         REPORTS: 30 * 24 * 60 * 60, // 30 days
+        // How long to keep extracted entities
+        ENTITIES: 7 * 24 * 60 * 60, // 7 days
     },
     REFRESH: {
         // Thresholds for background refresh (in seconds)
         MESSAGES: 5 * 60, // 5 minutes
         CHANNELS: 60 * 60, // 1 hour
         FEEDS: 2 * 60 * 60, // 2 hours
+        ENTITIES: 12 * 60 * 60, // 12 hours
     },
 };
 
@@ -171,6 +176,65 @@ FORMAT:
 </new_sources>
 
 Generate your complete JSON response now:
+`,
+    },
+    ENTITY_EXTRACTION: {
+        // Token estimation for entity extraction prompts
+        TOKEN_PER_CHAR: 1 / 4,
+        // Tokens reserved for model instructions
+        OVERHEAD_TOKENS: 500,
+        // Tokens reserved for output
+        OUTPUT_BUFFER: 4096,
+        // Maximum context window for entity extraction
+        MAX_CONTEXT_TOKENS: 32000,
+        // Maximum retries for entity extraction API calls
+        MAX_ATTEMPTS: 2,
+        // System prompt for entity extraction
+        SYSTEM_PROMPT: 'You are an expert entity extraction system. Extract entities from news text with high precision. Respond in valid JSON format with entity types, values, positions, and confidence scores.',
+
+        PROMPT_TEMPLATE: `
+Extract named entities from the following news text. Focus on entities that are relevant to news reporting and analysis.
+
+ENTITY TYPES TO EXTRACT:
+- PERSON: Names of individuals (politicians, officials, public figures, etc.)
+- ORGANIZATION: Companies, institutions, government agencies, political parties
+- LOCATION: Countries, cities, states, regions, specific places
+- EVENT: Named events, conferences, elections, operations
+- PRODUCT: Specific products, technologies, systems
+- MONEY: Monetary amounts, financial figures
+- DATE: Specific dates, time periods
+- MISC: Other significant entities not covered above
+
+EXTRACTION REQUIREMENTS:
+- Extract entities that appear in the text exactly as written
+- Provide confidence scores (0.0-1.0) based on contextual clarity
+- Calculate relevance scores (0.0-1.0) based on importance to the story
+- Include all mentions of each entity with precise text positions
+- Normalize similar entities (e.g., "Trump" and "Donald Trump" as same PERSON)
+- Focus on entities central to the news narrative
+
+TEXT TO ANALYZE:
+{text}
+
+Extract entities and respond with the following JSON structure:
+{
+  "entities": [
+    {
+      "type": "PERSON|ORGANIZATION|LOCATION|EVENT|PRODUCT|MONEY|DATE|MISC",
+      "value": "normalized entity name",
+      "mentions": [
+        {
+          "text": "exact text as it appears",
+          "startIndex": number,
+          "endIndex": number,
+          "confidence": number
+        }
+      ],
+      "relevanceScore": number,
+      "category": "optional subcategory"
+    }
+  ]
+}
 `,
     },
     BRAZIL_NEWS: {
@@ -297,4 +361,30 @@ export const RSS_FEEDS: Record<string, string> = {
     'UOL': 'https://rss.uol.com.br/feed/noticias.xml',
     'G1 - Política': 'https://g1.globo.com/rss/g1/politica/',
     'G1 - Economia': 'https://g1.globo.com/rss/g1/economia/',
+};
+
+export const ERROR_NO_OPENAI_KEY = 'Missing OPENAI_API_KEY';
+export const ERROR_NO_DISCORD_TOKEN = 'Missing DISCORD_BOT_TOKEN';
+
+export const ENTITY_COLORS: { [key: string]: string } = {
+    PERSON: '#4a90e2',
+    ORGANIZATION: '#7ed321',
+    LOCATION: '#e67e22',
+    EVENT: '#f5a623',
+    PRODUCT: '#4a4a4a',
+    MONEY: '#f8e71c',
+    DATE: '#bd10e0',
+    MISC: '#9b9b9b',
+    DEFAULT: '#888888'
+};
+
+export const ENTITY_LABELS: { [key: string]: string } = {
+    PERSON: 'People',
+    ORGANIZATION: 'Organizations',
+    LOCATION: 'Locations',
+    EVENT: 'Events',
+    PRODUCT: 'Products',
+    MONEY: 'Financial',
+    DATE: 'Dates',
+    MISC: 'Other',
 };

--- a/src/lib/cron.ts
+++ b/src/lib/cron.ts
@@ -42,9 +42,21 @@ export async function scheduled(event: ScheduledEvent, env: Cloudflare.Env): Pro
                 await reportService.generateReportsForManualTrigger(['6h'] as TimeframeKey[]);
                 taskResult = 'Generated 6h reports';
                 break;
+            case 'REPORTS_2H_NO_SOCIAL':
+                await reportService.generateReportsWithoutSocialMedia(['2h'] as TimeframeKey[]);
+                taskResult = 'Generated 2h reports without social media posting';
+                break;
+            case 'REPORTS_6H_NO_SOCIAL':
+                await reportService.generateReportsWithoutSocialMedia(['6h'] as TimeframeKey[]);
+                taskResult = 'Generated 6h reports without social media posting';
+                break;
             case 'REPORTS':
                 await reportService.generateReportsForManualTrigger('ALL');
                 taskResult = 'Generated all reports';
+                break;
+            case 'REPORTS_NO_SOCIAL':
+                await reportService.generateReportsWithoutSocialMedia('ALL');
+                taskResult = 'Generated all reports without social media posting';
                 break;
             case 'FEEDS':
                 await feedsService.createFreshSummary();

--- a/src/lib/hooks/useFilters.ts
+++ b/src/lib/hooks/useFilters.ts
@@ -13,16 +13,20 @@ interface Relationship {
     type: string;
 }
 
-export function useFilters() {
-    const [searchTerm, setSearchTerm] = useState('');
-    const [filters, setFilters] = useState<Record<'person' | 'company' | 'fund', boolean>>({
-        person: true,
-        company: true,
-        fund: true
-    });
+const DEFAULT_TYPES = ['person', 'company', 'fund'];
 
-    const toggleFilter = (type: 'person' | 'company' | 'fund') => {
-        setFilters(prev => ({ ...prev, [type]: !prev[type] }));
+export function useFilters(entityTypes: string[] = DEFAULT_TYPES) {
+    const [searchTerm, setSearchTerm] = useState('');
+
+    const initialFilters = entityTypes.reduce((acc, type) => {
+        acc[type.toLowerCase()] = true;
+        return acc;
+    }, {} as Record<string, boolean>);
+
+    const [filters, setFilters] = useState<Record<string, boolean>>(initialFilters);
+
+    const toggleFilter = (type: string) => {
+        setFilters(prev => ({ ...prev, [type.toLowerCase()]: !prev[type.toLowerCase()] }));
     };
 
     const isNodeVisible = (
@@ -41,12 +45,12 @@ export function useFilters() {
             );
             if (isConnected) {
                 // Respect type filters so user can still hide entire categories
-                return filters[node.type as 'person' | 'company' | 'fund'];
+                return filters[node.type.toLowerCase()];
             }
         }
 
         // Regular filtering when nothing selected (or not connected)
-        if (!filters[node.type as 'person' | 'company' | 'fund']) return false;
+        if (!filters[node.type.toLowerCase()]) return false;
         if (searchTerm.trim()) {
             return node.name.toLowerCase().includes(searchTerm.toLowerCase());
         }

--- a/src/lib/types/core.ts
+++ b/src/lib/types/core.ts
@@ -288,4 +288,60 @@ export interface TweetEmbed {
 
 export interface TweetEmbedCache {
     [tweetId: string]: TweetEmbed;
+}
+
+export interface EntityMention {
+    text: string;
+    startIndex: number;
+    endIndex: number;
+    confidence: number;
+}
+
+export interface ExtractedEntity {
+    type: 'PERSON' | 'ORGANIZATION' | 'LOCATION' | 'EVENT' | 'PRODUCT' | 'MONEY' | 'DATE' | 'MISC';
+    value: string;
+    mentions: EntityMention[];
+    relevanceScore: number;
+    category?: string;
+}
+
+export interface EntityExtractionResult {
+    entities: ExtractedEntity[];
+    extractedAt: string;
+    processingTimeMs: number;
+    sourceLength: number;
+}
+
+export interface EnhancedReport extends Report {
+    entities?: EntityExtractionResult;
+}
+
+export interface GraphNode {
+    id: string;
+    name: string;
+    type: string;
+    relevance: number;
+    connectionCount: number;
+}
+
+export interface GraphLink {
+    source: string;
+    target: string;
+    strength: number;
+}
+
+export interface GraphData {
+    nodes: GraphNode[];
+    links: GraphLink[];
+}
+
+export interface TransformedGraphData {
+    entities: { [key: string]: GraphNode };
+    relationships: { from: string; to: string; type: string; strength: number }[];
+}
+
+export interface Session {
+    user?: {
+        id: string;
+    };
 } 

--- a/src/lib/utils/entity-cache.ts
+++ b/src/lib/utils/entity-cache.ts
@@ -1,0 +1,104 @@
+import { CACHE } from '@/lib/config';
+import { EntityExtractionResult } from '@/lib/types/core';
+import { Cloudflare } from '../../../worker-configuration';
+import { CacheManager } from '../cache-utils';
+
+export class EntityCache {
+    /**
+     * Store entity extraction result for a report
+     */
+    static async store(reportId: string, entities: EntityExtractionResult, env: Cloudflare.Env): Promise<void> {
+        if (!env.ENTITIES_CACHE) {
+            throw new Error('Missing required KV namespace: ENTITIES_CACHE');
+        }
+        const cacheManager = new CacheManager(env);
+        const key = `entities:${reportId}`;
+        await cacheManager.put('ENTITIES_CACHE', key, entities, CACHE.TTL.ENTITIES);
+    }
+
+    /**
+     * Get cached entity extraction result for a report
+     */
+    static async get(reportId: string, env: Cloudflare.Env): Promise<EntityExtractionResult | null> {
+        if (!env.ENTITIES_CACHE) {
+            console.warn('ENTITIES_CACHE namespace not available');
+            return null;
+        }
+        const cacheManager = new CacheManager(env);
+        const key = `entities:${reportId}`;
+        return cacheManager.get<EntityExtractionResult>('ENTITIES_CACHE', key);
+    }
+
+    /**
+     * Batch get entity extraction results for multiple reports
+     */
+    static async batchGet(reportIds: string[], env: Cloudflare.Env): Promise<Map<string, EntityExtractionResult | null>> {
+        if (!env.ENTITIES_CACHE) {
+            console.warn('ENTITIES_CACHE namespace not available');
+            return new Map();
+        }
+        const cacheManager = new CacheManager(env);
+        const keys = reportIds.map(id => `entities:${id}`);
+        const results = await cacheManager.batchGet<EntityExtractionResult>('ENTITIES_CACHE', keys);
+
+        // Convert back to reportId-keyed map
+        const entityMap = new Map<string, EntityExtractionResult | null>();
+        reportIds.forEach((reportId, index) => {
+            const key = keys[index];
+            entityMap.set(reportId, results.get(key) || null);
+        });
+
+        return entityMap;
+    }
+
+    /**
+     * Check if entity extraction exists for a report
+     */
+    static async exists(reportId: string, env: Cloudflare.Env): Promise<boolean> {
+        const result = await this.get(reportId, env);
+        return result !== null;
+    }
+
+    /**
+     * Delete entity extraction for a report
+     */
+    static async delete(reportId: string, env: Cloudflare.Env): Promise<void> {
+        if (!env.ENTITIES_CACHE) {
+            return;
+        }
+        const cacheManager = new CacheManager(env);
+        const key = `entities:${reportId}`;
+        await cacheManager.delete('ENTITIES_CACHE', key);
+    }
+
+    /**
+     * List all entity cache keys (useful for maintenance)
+     */
+    static async listKeys(env: Cloudflare.Env): Promise<{ name: string }[]> {
+        if (!env.ENTITIES_CACHE) {
+            return [];
+        }
+        const cacheManager = new CacheManager(env);
+        const { keys } = await cacheManager.list('ENTITIES_CACHE', { prefix: 'entities:' });
+        return keys;
+    }
+
+    /**
+     * Get entity extraction results for multiple reports efficiently
+     * Used when displaying reports with their entities
+     */
+    static async getForReports(reportIds: string[], env: Cloudflare.Env): Promise<Record<string, EntityExtractionResult>> {
+        if (reportIds.length === 0) return {};
+
+        const entityMap = await this.batchGet(reportIds, env);
+        const result: Record<string, EntityExtractionResult> = {};
+
+        entityMap.forEach((entities, reportId) => {
+            if (entities) {
+                result[reportId] = entities;
+            }
+        });
+
+        return result;
+    }
+} 

--- a/src/lib/utils/entity-extraction.ts
+++ b/src/lib/utils/entity-extraction.ts
@@ -1,0 +1,304 @@
+import { getAIAPIKey, getAIProviderConfig } from '@/lib/ai-config';
+import { AI } from '@/lib/config';
+import { EntityExtractionResult, ExtractedEntity } from '@/lib/types/core';
+import { Cloudflare } from '../../../worker-configuration';
+import { EntityCache } from './entity-cache';
+
+export interface EntityExtractionContext {
+    reportId?: string;
+    channelId?: string;
+    sourceType: 'report' | 'message' | 'summary';
+    processingHint?: string;
+}
+
+export class EntityExtractor {
+    static async extract(
+        text: string,
+        context: EntityExtractionContext,
+        env: Cloudflare.Env
+    ): Promise<EntityExtractionResult> {
+        const startTime = performance.now();
+
+        // Skip extraction for very short texts
+        if (text.trim().length < 50) {
+            return {
+                entities: [],
+                extractedAt: new Date().toISOString(),
+                processingTimeMs: performance.now() - startTime,
+                sourceLength: text.length
+            };
+        }
+
+        let attempts = 0;
+        const maxAttempts = AI.ENTITY_EXTRACTION.MAX_ATTEMPTS;
+
+        while (attempts < maxAttempts) {
+            try {
+                const result = await this.makeEntityExtractionRequest(text, context, env);
+                const processingTimeMs = performance.now() - startTime;
+
+                console.log(`[ENTITIES] Extracted ${result.entities.length} entities from ${context.sourceType} in ${processingTimeMs.toFixed(2)}ms`);
+
+                return {
+                    ...result,
+                    extractedAt: new Date().toISOString(),
+                    processingTimeMs,
+                    sourceLength: text.length
+                };
+            } catch (error) {
+                attempts++;
+                if (attempts === maxAttempts) {
+                    console.error(`[ENTITIES] Failed to extract entities after ${maxAttempts} attempts:`, error);
+                    // Return empty result on final failure
+                    return {
+                        entities: [],
+                        extractedAt: new Date().toISOString(),
+                        processingTimeMs: performance.now() - startTime,
+                        sourceLength: text.length
+                    };
+                }
+                console.log(`[ENTITIES] Retrying entity extraction (${attempts}/${maxAttempts})`);
+                await new Promise(resolve => setTimeout(resolve, 1000));
+            }
+        }
+
+        throw new Error('Unreachable code');
+    }
+
+    private static async makeEntityExtractionRequest(
+        text: string,
+        context: EntityExtractionContext,
+        env: Cloudflare.Env
+    ): Promise<{ entities: ExtractedEntity[] }> {
+        const aiConfig = getAIProviderConfig();
+        const apiKey = getAIAPIKey(env as unknown as { [key: string]: string | undefined });
+
+        // Check for model override in environment (for testing)
+        const modelOverride = (env as unknown as { [key: string]: string | undefined }).AI_MODEL_OVERRIDE;
+        const modelToUse = modelOverride || aiConfig.model;
+
+        // Truncate text if it's too long for the context window
+        const maxTextLength = (AI.ENTITY_EXTRACTION.MAX_CONTEXT_TOKENS -
+            AI.ENTITY_EXTRACTION.OVERHEAD_TOKENS -
+            AI.ENTITY_EXTRACTION.OUTPUT_BUFFER) / AI.ENTITY_EXTRACTION.TOKEN_PER_CHAR;
+
+        const truncatedText = text.length > maxTextLength
+            ? text.substring(0, maxTextLength) + '...'
+            : text;
+
+        const prompt = AI.ENTITY_EXTRACTION.PROMPT_TEMPLATE.replace('{text}', truncatedText);
+
+        const response = await fetch(aiConfig.endpoint, {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${apiKey}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                messages: [
+                    {
+                        role: "system",
+                        content: AI.ENTITY_EXTRACTION.SYSTEM_PROMPT,
+                    },
+                    { role: "user", content: prompt }
+                ],
+                model: modelToUse,
+                max_tokens: AI.ENTITY_EXTRACTION.OUTPUT_BUFFER,
+                temperature: 0.1, // Low temperature for consistent extraction
+                response_format: {
+                    type: "json_schema",
+                    json_schema: {
+                        name: "entity_extraction",
+                        strict: true,
+                        schema: {
+                            type: "object",
+                            properties: {
+                                entities: {
+                                    type: "array",
+                                    items: {
+                                        type: "object",
+                                        properties: {
+                                            type: {
+                                                type: "string",
+                                                enum: ["PERSON", "ORGANIZATION", "LOCATION", "EVENT", "PRODUCT", "MONEY", "DATE", "MISC"]
+                                            },
+                                            value: {
+                                                type: "string",
+                                                description: "Normalized entity name"
+                                            },
+                                            mentions: {
+                                                type: "array",
+                                                items: {
+                                                    type: "object",
+                                                    properties: {
+                                                        text: { type: "string" },
+                                                        startIndex: { type: "number" },
+                                                        endIndex: { type: "number" },
+                                                        confidence: { type: "number", minimum: 0, maximum: 1 }
+                                                    },
+                                                    required: ["text", "startIndex", "endIndex", "confidence"],
+                                                    additionalProperties: false
+                                                }
+                                            },
+                                            relevanceScore: {
+                                                type: "number",
+                                                minimum: 0,
+                                                maximum: 1,
+                                                description: "Relevance to the story (0.0-1.0)"
+                                            },
+                                            category: {
+                                                type: "string",
+                                                description: "Optional subcategory"
+                                            }
+                                        },
+                                        required: ["type", "value", "mentions", "relevanceScore"],
+                                        additionalProperties: false
+                                    }
+                                }
+                            },
+                            required: ["entities"],
+                            additionalProperties: false
+                        }
+                    }
+                }
+            }),
+        });
+
+        if (!response.ok) {
+            throw new Error(`Entity extraction API request failed: ${response.status} - ${await response.text()}`);
+        }
+
+        const data = await response.json() as { choices?: Array<{ message?: { content?: string } }> };
+        const content = data.choices?.[0]?.message?.content;
+        if (!content) throw new Error('No content returned from entity extraction API');
+
+        let extractionData: { entities?: ExtractedEntity[] };
+        try {
+            extractionData = JSON.parse(content);
+        } catch (parseError) {
+            console.error(`[ENTITIES] Failed to parse entity extraction JSON response:`, parseError);
+            console.error(`[ENTITIES] Raw response: "${content}"`);
+            throw new Error('Invalid JSON format received from entity extraction API');
+        }
+
+        // Validate and sanitize the response
+        const entities = (extractionData.entities || []).filter(entity => {
+            // Basic validation
+            if (!entity.type || !entity.value || !Array.isArray(entity.mentions)) {
+                return false;
+            }
+
+            // Validate mentions
+            entity.mentions = entity.mentions.filter(mention => {
+                return mention.text &&
+                    typeof mention.startIndex === 'number' &&
+                    typeof mention.endIndex === 'number' &&
+                    typeof mention.confidence === 'number' &&
+                    mention.confidence >= 0 && mention.confidence <= 1;
+            });
+
+            // Keep entity only if it has valid mentions
+            return entity.mentions.length > 0;
+        });
+
+        // Sort entities by relevance score (highest first)
+        entities.sort((a, b) => (b.relevanceScore || 0) - (a.relevanceScore || 0));
+
+        return { entities };
+    }
+
+    /**
+     * Extract entities from a full report (headline + body) with caching
+     */
+    static async extractFromReport(
+        headline: string,
+        body: string,
+        reportId: string,
+        channelId: string,
+        env: Cloudflare.Env
+    ): Promise<EntityExtractionResult> {
+        // Check cache first
+        try {
+            const cachedResult = await EntityCache.get(reportId, env);
+            if (cachedResult) {
+                console.log(`[ENTITIES] Cache hit for report ${reportId}`);
+                return cachedResult;
+            }
+        } catch (cacheError) {
+            console.warn(`[ENTITIES] Cache read failed for report ${reportId}:`, cacheError);
+            // Continue with extraction if cache fails
+        }
+
+        console.log(`[ENTITIES] Cache miss for report ${reportId}, extracting entities`);
+
+        // Extract entities
+        const fullText = `${headline}\n\n${body}`;
+        const result = await this.extract(fullText, {
+            reportId,
+            channelId,
+            sourceType: 'report',
+            processingHint: 'news report'
+        }, env);
+
+        // Cache the result
+        try {
+            await EntityCache.store(reportId, result, env);
+            console.log(`[ENTITIES] Cached entities for report ${reportId}`);
+        } catch (cacheError) {
+            console.warn(`[ENTITIES] Failed to cache entities for report ${reportId}:`, cacheError);
+            // Don't fail the operation if caching fails
+        }
+
+        return result;
+    }
+
+    /**
+     * Get cached entities for a report, if available
+     */
+    static async getCachedEntities(reportId: string, env: Cloudflare.Env): Promise<EntityExtractionResult | null> {
+        return EntityCache.get(reportId, env);
+    }
+
+    /**
+     * Get entities for multiple reports efficiently
+     */
+    static async getEntitiesForReports(reportIds: string[], env: Cloudflare.Env): Promise<Record<string, EntityExtractionResult>> {
+        return EntityCache.getForReports(reportIds, env);
+    }
+
+    /**
+     * Filter entities by type and minimum relevance score
+     */
+    static filterEntities(
+        entities: ExtractedEntity[],
+        types?: Array<ExtractedEntity['type']>,
+        minRelevance = 0.3
+    ): ExtractedEntity[] {
+        return entities.filter(entity => {
+            if (entity.relevanceScore < minRelevance) return false;
+            if (types && !types.includes(entity.type)) return false;
+            return true;
+        });
+    }
+
+    /**
+     * Get top entities by type
+     */
+    static getTopEntitiesByType(
+        entities: ExtractedEntity[],
+        maxPerType = 5
+    ): Record<string, ExtractedEntity[]> {
+        const grouped: Record<string, ExtractedEntity[]> = {};
+
+        entities.forEach(entity => {
+            if (!grouped[entity.type]) {
+                grouped[entity.type] = [];
+            }
+            if (grouped[entity.type].length < maxPerType) {
+                grouped[entity.type].push(entity);
+            }
+        });
+
+        return grouped;
+    }
+} 

--- a/src/lib/utils/report-ai.ts
+++ b/src/lib/utils/report-ai.ts
@@ -26,6 +26,7 @@ export class ReportAI {
         while (attempts < maxAttempts) {
             try {
                 const report = await this.makeAIRequest(promptData.prompt, messages, context, env);
+
                 console.log(`[REPORTS] Generated ${context.timeframe} report for channel ${context.channelName} - ${context.messageCount} messages and ${promptData.tokenCount} tokens.`);
                 return report;
             } catch (error) {

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -11,6 +11,7 @@ export declare namespace Cloudflare {
         AUTH_TOKENS: KVNamespace;
         GEOCODE_CACHE: KVNamespace;
         FEEDS_CACHE: KVNamespace;
+        ENTITIES_CACHE: KVNamespace;
         R2_PUBLIC_URL: "https://images.fasttakeoff.org";
         DISCORD_TOKEN: string;
         DISCORD_GUILD_ID: string;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -50,6 +50,11 @@ binding = "FEEDS_CACHE"
 id = "570aca506a0c42a3bbae031791885844"
 preview_id = "4bc7359368524a13a666e1bfbb177802"
 
+[[kv_namespaces]]
+binding = "ENTITIES_CACHE"
+id = "60c184aac065460db20c1a6d07355cba"
+preview_id = "206f66b9c1b44d5d8b2904bf22b3b006"
+
 # R2 bucket binding for Instagram images
 [[r2_buckets]]
 binding = "INSTAGRAM_IMAGES"


### PR DESCRIPTION
### ✨  What’s new  
1. **Entity-extraction pipeline**  
   • Added `src/lib/utils/entity-extraction.ts` with OpenAI-powered NER, plus `entity-cache.ts` for KV storage  
   • New KV namespace `ENTITIES_CACHE` (updated in `wrangler.toml` & `worker-configuration.d.ts`)  
   • REST endpoint `POST /api/entities` (`src/app/api/entities/route.ts`) for on-demand refresh & retrieval  
   • Integrated into report generation (`report-service.ts`) and scheduled via `cron.ts`  

2. **“Entities” section in UI**  
   • Route `/entities` with list view (`EntitiesClient.tsx`) and detail cards (`EntityDisplay.tsx`)  
   • Interactive graph at `/entities/graph` (`EntityGraphClient.tsx`) built on D3 force-simulation  
   • Added “Entities” link to global `Header.tsx` navigation  

3. **Power-network visualization enhancements**  
   • Re-worked force-simulation: collision detection, strength-aware link forces, & FPS friendly defaults  
   • Optimised canvas renderer with dynamic node styling, label visibility, and color mapping  
   • Refactored hooks (`useForceSimulation`, `useNetworkRenderer`, `useNodes`, `useFilters`) for reuse across graphs  

4. **Config & types**  
   • Expanded `config.ts` with `ENTITY_EXTRACTION` settings (TTLs, colour palette, labels)  
   • Extended core types (`types/core.ts`) with `Entity`, `EntityEdge`, and graph shapes  

5. **Developer ergonomics**  
   • Added manual cron helpers for local report generation without social posting  
   • Minor log-readability tweak in `report-ai.ts`  

### 🛠  Files touched (1 780 insertions / 160 deletions)  
Key additions:  
```
src/app/api/entities/route.ts
src/app/entities/*                          # new pages & components
src/lib/utils/entity-{extraction,cache}.ts
src/lib/hooks/use*                          # generalized hooks
wrangler.toml                               # ENTITIES_CACHE
```

### ✅  How to test  
1. `npm run preview:patch:test` – full Cloudflare-worker build & tests  
2. Browse `/entities` and `/entities/graph` to verify list & graph render  
3. Hit `POST /api/entities` with `?regen=true` to force a refresh and confirm KV writes  
4. Open Power-Network page; observe smoother physics & lower CPU on large datasets  

### 📌  Motivation  
Having structured entities unlocks richer cross-story insights (e.g., people, organizations, locations) and paves the way for advanced features like influence graphs and entity-centric alerts. Graph UI + power-network perf improvements provide a scalable foundation for visual analytics as data volume grows.

### ⚠️  Notes / follow-ups  
• No schema migrations required; KV namespace auto-provisioned via Wrangler  
• Future work: surface entity filters in Current-Events feed, add unit tests for extraction utility  