### PR TITLE
Make bold tags render text as bold

### DIFF
--- a/src/app/mktfeed/MktFeedClient.tsx
+++ b/src/app/mktfeed/MktFeedClient.tsx
@@ -13,12 +13,30 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 
 // Format market news text by handling common patterns
-function formatMarketText(text: string): string {
-    // Remove HTML tags and convert to uppercase if entire text is wrapped in <B> tags
-    if (text.startsWith('<B>') && text.endsWith('</B>')) {
-        return text.replace(/<\/?B>/g, '').toUpperCase();
+function formatMarketText(text: string): React.ReactNode {
+    // Handle <B> and <b> tags within the text
+    const parts = text.split(/(<\/?[Bb]>)/);
+    const result: React.ReactNode[] = [];
+    let isBold = false;
+    
+    for (let i = 0; i < parts.length; i++) {
+        const part = parts[i];
+        
+        if (part === '<B>' || part === '<b>') {
+            isBold = true;
+        } else if (part === '</B>' || part === '</b>') {
+            isBold = false;
+        } else if (part) {
+            // Only add non-empty parts
+            if (isBold) {
+                result.push(<strong key={i}>{part}</strong>);
+            } else {
+                result.push(part);
+            }
+        }
     }
-    return text;
+    
+    return result.length > 0 ? result : text;
 }
 
 interface MktFeedResponse {


### PR DESCRIPTION
Format market feed text to display `<B>` and `<b>` sections as bold.

---

[Open in Web](https://www.cursor.com/agents?id=bc-06fee277-0868-4179-8edd-9c1ae4e3410a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-06fee277-0868-4179-8edd-9c1ae4e3410a)