### PR TITLE
Revert color change from orange to green

### DIFF
--- a/src/app/critical.css
+++ b/src/app/critical.css
@@ -33,7 +33,7 @@ main {
 .hero-title {
   font-size: 3.75rem;
   font-weight: 700;
-  background: linear-gradient(135deg, #f59e0b, #f97316, #ea580c); /* Amber to Orange gradient */
+  background: linear-gradient(135deg, #0d6b5a, #158a73); /* Green/Teal gradient */
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,11 +19,11 @@
   --popover: #1a1a1a; /* Slightly lighter for popovers */
   --popover-foreground: #f3f4f6;
 
-  /* Primary - Industrial Amber/Orange */
-  --primary: #f59e0b; /* Amber-500 */
-  --primary-hover: #f97316; /* Orange-500 */
+  /* Primary - Fast Takeoff Green/Teal */
+  --primary: #0d6b5a; /* Teal */
+  --primary-hover: #158a73; /* Teal hover */
   --primary-foreground: #ffffff;
-  --primary-light: rgba(245, 158, 11, 0.1);
+  --primary-light: rgba(13, 107, 90, 0.1);
 
   /* Secondary - Dark Gray */
   --secondary: #1f2937; /* Gray-800 */
@@ -36,9 +36,9 @@
   --muted-light: rgba(243, 244, 246, 0.05);
   --muted-lighter: rgba(243, 244, 246, 0.03);
 
-  /* Accent - Industrial Orange */
-  --accent: #ea580c; /* Orange-600 */
-  --accent-hover: #dc2626; /* Red-600 */
+  /* Accent - Green */
+  --accent: #1db39c; /* Green */
+  --accent-hover: #25c7ae; /* Green hover */
   --accent-foreground: #ffffff;
 
   /* Destructive - Industrial Red */
@@ -52,8 +52,8 @@
   --soft-border: #6b7280; /* Gray-500 */
   --soft-border-foreground: #d1d5db; /* Gray-300 */
   --input: #1f2937; /* Gray-800 */
-  --ring: #f59e0b; /* Amber-500 */
-  --ring-hover: #f97316; /* Orange-500 */
+  --ring: #1db39c; /* Green */
+  --ring-hover: #25c7ae; /* Green hover */
 
   /* Radius */
   --radius: 0.625rem;

--- a/src/components/HomeContent.tsx
+++ b/src/components/HomeContent.tsx
@@ -71,13 +71,13 @@ export default function HomeContent({ initialReports, initialExecutiveOrders, in
 
                 <div className="flex flex-col items-center gap-4 sm:gap-6 py-8 sm:py-12 px-6 w-full relative z-10">
                     {/* Social Proof Badge - Industrial styling */}
-                    <div className="bg-gradient-to-r from-amber-600/20 to-orange-600/20 text-amber-300 border border-amber-500/40 px-4 py-2 rounded-full text-sm font-medium backdrop-blur-sm shadow-lg shadow-amber-500/10">
+                    <div className="bg-gradient-to-r from-emerald-600/20 to-teal-600/20 text-emerald-300 border border-emerald-500/40 px-4 py-2 rounded-full text-sm font-medium backdrop-blur-sm shadow-lg shadow-emerald-500/10">
                         ⚡ Real-time AI analysis from global sources
                     </div>
 
                     {/* Headlines & Value Props - Industrial color scheme */}
                     <div className="flex flex-col items-center gap-4 text-center max-w-3xl">
-                        <h1 className="hero-title text-5xl md:text-7xl font-bold bg-gradient-to-r from-amber-400 via-orange-400 to-red-400 bg-clip-text text-transparent leading-tight drop-shadow-lg">
+                        <h1 className="hero-title text-5xl md:text-7xl font-bold bg-gradient-to-r from-emerald-400 via-teal-400 to-green-400 bg-clip-text text-transparent leading-tight drop-shadow-lg">
                             AI-Powered News Intelligence
                         </h1>
                     </div>
@@ -98,13 +98,13 @@ export default function HomeContent({ initialReports, initialExecutiveOrders, in
                                         onChange={(e) => setEmail(e.target.value)}
                                         disabled={isSubmitting}
                                         required
-                                        className="h-10 sm:h-12 text-base sm:text-lg bg-gray-800 border-gray-600 text-gray-100 placeholder-gray-500 focus:border-amber-500 focus:ring-amber-500 focus:bg-gray-700"
+                                        className="h-10 sm:h-12 text-base sm:text-lg bg-gray-800 border-gray-600 text-gray-100 placeholder-gray-500 focus:border-emerald-500 focus:ring-emerald-500 focus:bg-gray-700"
                                     />
 
                                     <Button
                                         type="submit"
                                         disabled={isSubmitting}
-                                        className="w-full h-10 sm:h-12 text-base sm:text-lg font-semibold bg-gradient-to-r from-amber-600 to-orange-600 hover:from-amber-700 hover:to-orange-700 text-white shadow-lg hover:shadow-xl transition-all duration-200 border border-amber-500/30"
+                                        className="w-full h-10 sm:h-12 text-base sm:text-lg font-semibold bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-700 hover:to-teal-700 text-white shadow-lg hover:shadow-xl transition-all duration-200 border border-emerald-500/30"
                                     >
                                         {isSubmitting ? "Setting up your briefings..." : "Get Free Daily Briefings →"}
                                     </Button>
@@ -129,7 +129,7 @@ export default function HomeContent({ initialReports, initialExecutiveOrders, in
                             Want advanced features and premium insights?
                         </p>
                         <Link href="/sign-up">
-                            <Button variant="outline" className="border-amber-500/50 text-amber-300 hover:bg-amber-500/10 hover:text-amber-200 backdrop-blur-sm bg-gray-900/50">
+                            <Button variant="outline" className="border-emerald-500/50 text-emerald-300 hover:bg-emerald-500/10 hover:text-emerald-200 backdrop-blur-sm bg-gray-900/50">
                                 Create Free Account
                             </Button>
                         </Link>
@@ -146,26 +146,26 @@ export default function HomeContent({ initialReports, initialExecutiveOrders, in
             <section className="mb-6 mx-6 sm:mx-8">
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
                     <Link href="/current-events" className="group">
-                        <div className="bg-gradient-to-br from-gray-800 via-gray-900 to-black rounded-lg shadow-xl hover:shadow-2xl transition-all duration-300 p-6 border border-gray-600/50 hover:border-amber-500/50 backdrop-blur-sm">
-                            <h3 className="text-lg font-semibold text-gray-100 group-hover:text-amber-400 transition-colors">Current Events</h3>
+                        <div className="bg-gradient-to-br from-gray-800 via-gray-900 to-black rounded-lg shadow-xl hover:shadow-2xl transition-all duration-300 p-6 border border-gray-600/50 hover:border-emerald-500/50 backdrop-blur-sm">
+                            <h3 className="text-lg font-semibold text-gray-100 group-hover:text-emerald-400 transition-colors">Current Events</h3>
                             <p className="text-sm text-gray-200 mt-2">Real-time news from on-the-ground sources</p>
                         </div>
                     </Link>
                     <Link href="/news-globe" className="group">
-                        <div className="bg-gradient-to-br from-gray-800 via-gray-900 to-black rounded-lg shadow-xl hover:shadow-2xl transition-all duration-300 p-6 border border-gray-600/50 hover:border-amber-500/50 backdrop-blur-sm">
-                            <h3 className="text-lg font-semibold text-gray-100 group-hover:text-amber-400 transition-colors">News Globe</h3>
+                        <div className="bg-gradient-to-br from-gray-800 via-gray-900 to-black rounded-lg shadow-xl hover:shadow-2xl transition-all duration-300 p-6 border border-gray-600/50 hover:border-emerald-500/50 backdrop-blur-sm">
+                            <h3 className="text-lg font-semibold text-gray-100 group-hover:text-emerald-400 transition-colors">News Globe</h3>
                             <p className="text-sm text-gray-200 mt-2">Interactive 3D visualization of global news</p>
                         </div>
                     </Link>
                     <Link href="/brazil" className="group">
-                        <div className="bg-gradient-to-br from-gray-800 via-gray-900 to-black rounded-lg shadow-xl hover:shadow-2xl transition-all duration-300 p-6 border border-gray-600/50 hover:border-amber-500/50 backdrop-blur-sm">
-                            <h3 className="text-lg font-semibold text-gray-100 group-hover:text-amber-400 transition-colors">Brazil</h3>
+                        <div className="bg-gradient-to-br from-gray-800 via-gray-900 to-black rounded-lg shadow-xl hover:shadow-2xl transition-all duration-300 p-6 border border-gray-600/50 hover:border-emerald-500/50 backdrop-blur-sm">
+                            <h3 className="text-lg font-semibold text-gray-100 group-hover:text-emerald-400 transition-colors">Brazil</h3>
                             <p className="text-sm text-gray-200 mt-2">AI-curated Brazilian news summaries</p>
                         </div>
                     </Link>
                     <Link href="/power-network" className="group">
-                        <div className="bg-gradient-to-br from-gray-800 via-gray-900 to-black rounded-lg shadow-xl hover:shadow-2xl transition-all duration-300 p-6 border border-gray-600/50 hover:border-amber-500/50 backdrop-blur-sm">
-                            <h3 className="text-lg font-semibold text-gray-100 group-hover:text-amber-400 transition-colors">Power Network</h3>
+                        <div className="bg-gradient-to-br from-gray-800 via-gray-900 to-black rounded-lg shadow-xl hover:shadow-2xl transition-all duration-300 p-6 border border-gray-600/50 hover:border-emerald-500/50 backdrop-blur-sm">
+                            <h3 className="text-lg font-semibold text-gray-100 group-hover:text-emerald-400 transition-colors">Power Network</h3>
                             <p className="text-sm text-gray-200 mt-2">Explore influential people and companies</p>
                         </div>
                     </Link>
@@ -176,7 +176,7 @@ export default function HomeContent({ initialReports, initialExecutiveOrders, in
             <section className="mx-6 sm:mx-8">
                 <div className="flex items-center justify-between mb-6">
                     <h2 className="text-2xl md:text-3xl font-bold text-gray-100">Latest Reports</h2>
-                    <Link href="/current-events" className="text-sm font-medium text-amber-400 hover:text-amber-300 hover:underline">
+                    <Link href="/current-events" className="text-sm font-medium text-emerald-400 hover:text-emerald-300 hover:underline">
                         View all reports →
                     </Link>
                 </div>
@@ -209,7 +209,7 @@ export default function HomeContent({ initialReports, initialExecutiveOrders, in
                     <div className="flex flex-col gap-6">
                         <div className="flex items-center justify-between">
                             <h2 className="text-2xl font-bold tracking-tight md:text-3xl text-gray-100">Latest Executive Orders</h2>
-                            <Link href="/executive-orders" className="text-sm font-medium text-amber-400 hover:text-amber-300 hover:underline">
+                            <Link href="/executive-orders" className="text-sm font-medium text-emerald-400 hover:text-emerald-300 hover:underline">
                                 View all →
                             </Link>
                         </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -95,15 +95,15 @@ module.exports = {
       },
       // Industrial theme gradients
       backgroundImage: {
-        'industrial-gradient': 'linear-gradient(135deg, #f59e0b 0%, #f97316 50%, #ea580c 100%)',
+        'industrial-gradient': 'linear-gradient(135deg, #0d6b5a 0%, #158a73 50%, #1db39c 100%)',
         'dark-gradient': 'linear-gradient(135deg, #0a0a0a 0%, #111827 50%, #1f2937 100%)',
         'card-gradient': 'linear-gradient(135deg, #111111 0%, #1f2937 100%)',
         'metallic': 'linear-gradient(135deg, rgba(255,255,255,0.02) 0%, transparent 50%)',
       },
       // Industrial shadows
       boxShadow: {
-        'industrial': '0 10px 25px -3px rgba(245, 158, 11, 0.1), 0 4px 6px -2px rgba(245, 158, 11, 0.05)',
-        'industrial-lg': '0 20px 25px -5px rgba(245, 158, 11, 0.1), 0 10px 10px -5px rgba(245, 158, 11, 0.04)',
+        'industrial': '0 10px 25px -3px rgba(16, 185, 129, 0.10), 0 4px 6px -2px rgba(16, 185, 129, 0.05)',
+        'industrial-lg': '0 20px 25px -5px rgba(16, 185, 129, 0.10), 0 10px 10px -5px rgba(16, 185, 129, 0.04)',
         'dark': '0 10px 25px -3px rgba(0, 0, 0, 0.3), 0 4px 6px -2px rgba(0, 0, 0, 0.2)',
       },
     },


### PR DESCRIPTION
Revert primary UI theme from orange/amber to green/teal.

The user requested to revert a previous color change. The primary theme was switched to amber/orange in commit `61ad05db` (Aug 7, 2025), and this PR reverts the relevant CSS variables, gradients, and Tailwind classes to green/teal.

---
<a href="https://cursor.com/background-agent?bcId=bc-f55bcf0e-8c64-4c94-8287-dae12752f7ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f55bcf0e-8c64-4c94-8287-dae12752f7ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

